### PR TITLE
version is tracked in one place only; closes #54

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -152,18 +152,13 @@ Then run:
 1. Bump the version by editing ``__version__`` in ``parselglossy/__init__.py``.
    For this follow `PEP 440 <https://www.python.org/dev/peps/pep-0440/>`_.
 
-2. Stage and commit the change::
+2. Stage and commit the change to a branch::
 
    $ git add parselglossy/__init__.py
    $ git commit -sm "Bump version: x.y.z -> X.Y.Z"
 
-3. Tag the release::
+3. Submit a pull request targetting either the ``master`` branch or a
+   release branch.
 
-   $ git tag -a vX.Y.Z -m "Version X.Y.Z release" -s # -s is to GPG-sign the tag
-
-4. Push latest commits and the tag. Remember to disengage branch protection for the ``master`` branch::
-
-   $ git push
-   $ git push --tags
-
-Travis will then deploy to PyPI if tests pass for the Python 3.6 lane.
+4. Once the pull request is accepted, create a release via the GitHub web user interface.
+   Travis will then deploy to PyPI if tests pass for the Python 3.6 lane.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -149,13 +149,12 @@ A reminder for the maintainers on how to deploy.
 Make sure all your changes are committed (including an entry in ``HISTORY.rst``).
 Then run:
 
-1. Bump the version using the ``bumpversion`` executable::
+1. Bump the version by editing ``__version__`` in ``parselglossy/__init__.py``.
+   For this follow `PEP 440 <https://www.python.org/dev/peps/pep-0440/>`_.
 
-   $ bumpversion patch --no-tag --no-commit # possible: major / minor / patch
+2. Stage and commit the change::
 
-2. Make sure that the files touched by ``bumpversion`` all look correct. Then add them and commit::
-
-   $ git add setup.py  setup.cfg parselglossy/__init__.py
+   $ git add parselglossy/__init__.py
    $ git commit -sm "Bump version: x.y.z -> X.Y.Z"
 
 3. Tag the release::

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,6 @@ verify_ssl = true
 
 [dev-packages]
 Sphinx = "*"
-bumpversion = "*"
 codecov = "*"
 coverage = "*"
 flake8 = "*"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,16 +1,3 @@
-[bumpversion]
-current_version = 0.2.0
-commit = False
-tag = False
-
-[bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
-
-[bumpversion:file:parselglossy/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
-
 [bdist_wheel]
 universal = 1
 

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,19 @@
 """The setup script."""
 
 from setuptools import find_packages, setup
+from pathlib import Path
 
 with open("README.rst") as readme_file:
     readme = readme_file.read()
 
 with open("HISTORY.rst") as history_file:
     history = history_file.read()
+
+# extract __version__ from __init__.py
+_version = {}
+with Path("parselglossy/__init__.py").open("r") as f:
+    exec(f.read(), _version)
+version=_version['__version__']
 
 requirements = ["Click>=6.0", "pyparsing>=2.2", "pyyaml>=3.13"]
 
@@ -41,6 +48,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/dev-cafe/parselglossy",
-    version="0.2.0",
+    version=version,
     zip_safe=False,
 )


### PR DESCRIPTION
With this we do not need bumpversion anymore.