### PR TITLE
Remove some dev dependencies & fix API docs rendering

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,9 +4,10 @@ formats:
   - pdf
 python:
   version: 3.6
-   install:
-      - requirements: docs/requirements.txt
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
 sphinx:
   builder: html
   configuration: docs/conf.py
-

--- a/Makefile
+++ b/Makefile
@@ -69,12 +69,6 @@ docs: ## generate Sphinx HTML documentation, including API docs
 	$(MAKE) -C docs html
 	$(BROWSER) docs/_build/html/index.html
 
-servedocs: docs ## compile the docs watching for changes
-	watchmedo shell-command -p '*.rst' -c '$(MAKE) -C docs html' -R -D .
-
-release: dist ## package and upload a release
-	twine upload dist/*
-
 dist: clean ## builds source and wheel package
 	python setup.py sdist
 	python setup.py bdist_wheel

--- a/Pipfile
+++ b/Pipfile
@@ -3,20 +3,15 @@ url = "https://pypi.python.org/simple"
 verify_ssl = true
 
 [dev-packages]
-Sphinx = "*"
 codecov = "*"
 coverage = "*"
 flake8 = "*"
-guzzle-sphinx-theme = "*"
 hypothesis = "*"
 ipython = "*"
 pytest = "*"
 pytest-cov = "*"
 pytest-mypy = "*"
 pytest-flake8 = "*"
-twine = "*"
-watchdog = "*"
-wheel = "*"
 
 [packages]
 click = "*"


### PR DESCRIPTION
- Sphinx is a dependency only for docs
- Deployment is done only on tags and automatically by Travis. Twine & co are not needed.
- API docs are properly rendered. See here: https://parselglossy.readthedocs.io/en/additional-types/parselglossy.exceptions.html