### PR TITLE
Provide minimal (generator-only) CLI

### DIFF
--- a/parselglossy/api.py
+++ b/parselglossy/api.py
@@ -60,28 +60,27 @@ def generate(
     template : Union[str, Path]
         Which validation template to use.
     where : Union[str, Path]
-        Where to generate the parsing module. Default to `input_parser` folder
+        Where to generate the parsing module. Default to ``input_parser`` folder
         under current working directory.
     grammar : Union[str, Path, List[Path]]
         The file containing the grammar to use to tokenize user input.
-        Defaults to `standard`, *i.e.* use one of the grammars packaged with
-        the library.
+        Defaults to ``standard``, *i.e.* use one of the grammars packaged with
+        the library, based on ``pyparsing``.
     tokenize : Optional[str]
         The commands to perform lexing of the input with a custom grammar. The
-        result of these commands must be a variable named `ir` of type
-        `Dict[str, Any]`.
-        Defaults to `None`.
+        result of these commands must be a variable named ``ir`` of type
+        ``Dict[str, Any]``.
+        Defaults to ``None``.
     docfile : str
         The name of the documentation file for the input.
-        Defaults to `input.rst`.
+        Defaults to ``input.rst``.
     doc_header : str
         Header for the documentation page.
         Defaults to ``Input parameters``.
 
     Returns
     -------
-    parser_dir : Path
-        Location of generated parser Python module
+    Location of generated parser Python module as a ``Path`` object.
 
     Notes
     -----
@@ -90,22 +89,24 @@ def generate(
 
     The user can provide a grammar as (a list of) external file(s).
     There are a few constraints:
-       - The function performing tokenization **must return** an object of
-    ``Dict[str, Any]`` type: a, potentially recursive, dictionary of keys and
-    values.
-       - Commands to perform tokenization are passed *via* the `tokenize` input
-         parameters. This is a string that will copied *verbatim* in the
-         generated code, relevant `import` statements have to be included in
-         this string!
-       - The result of the commands in `tokenize` must be a variable named
-         `ir`.
-       - It is the responsibility of the user to satisfy any dependencies of
-         the parsing grammar they provided.
+
+    * The function performing tokenization **must return** an object of
+      ``Dict[str, Any]`` type: a, potentially recursive, dictionary of keys and
+      values.
+    * Commands to perform tokenization are passed *via* the ``tokenize`` input
+      parameters. This is a string that will copied *verbatim* in the
+      generated code, relevant ``import`` statements have to be included in
+      this string!
+    * The result of the commands in ``tokenize`` must be a variable named
+      ``ir``.
+    * It is the responsibility of the user to satisfy any dependencies of
+      the parsing grammar they provided.
 
     Raises
     ------
     :exc:`ParselglossyError`
     """
+
     where_ = path_resolver(where, touch=False)
 
     # validate grammar options

--- a/parselglossy/cli.py
+++ b/parselglossy/cli.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # parselglossy -- Generic input parsing library, speaking in tongues
 # Copyright (C) 2019 Roberto Di Remigio, Radovan Bast, and contributors.
@@ -26,16 +27,15 @@
 # parselglossy library, see: <http://parselglossy.readthedocs.io/>
 #
 
-# -*- coding: utf-8 -*-
 """Console script for parselglossy."""
 
 from pathlib import Path
-from typing import Union, List
+from typing import List, Union
 
 import click
 
-from . import __version__, api
-from .utils import default_outfile
+from . import __version__
+from .api import generate
 
 
 @click.group()
@@ -43,206 +43,6 @@ from .utils import default_outfile
 def cli(args=None):
     """Console script for parselglossy."""
     return 0
-
-
-@click.command(name="lex")
-@click.argument(
-    "infile",
-    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
-    metavar="<infile>",
-)
-@click.option(
-    "--outfile",
-    type=click.Path(exists=False, dir_okay=False, resolve_path=True),
-    default=None,
-    help="name or path for the lexed output JSON file",
-    metavar="<outfile>",
-)
-@click.option(
-    "--grammar",
-    default="standard",
-    type=click.Choice(["standard", "getkw"]),
-    show_default=True,
-    help="which grammar to use",
-    metavar="<grammar>",
-)
-def _lex(infile: str, outfile: str, grammar: str) -> None:
-    """Run lexer and dump intermediate representation to JSON.
-
-    \b
-    Parameters
-    ----------
-    infile : str
-        The input file to be parsed.
-    outfile : str
-        The output file. By default, save as ``<infile>_ir.json`` in the
-        current working directory.
-    grammar : str
-        Which grammar to use.
-    """
-
-    if outfile is None:
-        outfile = default_outfile(fname=infile, suffix="_ir.json")
-
-    api.lex(infile=infile, grammar=grammar, ir_file=outfile)
-
-
-@click.command(name="validate")
-@click.argument(
-    "infile",
-    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
-    metavar="<infile>",
-)
-@click.option(
-    "--outfile",
-    type=click.Path(exists=False, dir_okay=False, resolve_path=True),
-    default=None,
-    help="name or path for the validated output JSON file",
-    metavar="<outfile>",
-)
-@click.option(
-    "--template",
-    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
-    metavar="<template>",
-    help="which validation template to use",
-)
-def _validate(infile: str, outfile: str, template: str) -> None:
-    """Validate intermediate representation into final representation.
-
-    \b
-    Parameters
-    ----------
-    infile : str
-        The input file to be parsed.
-    outfile : str
-        The output file. Defaults to ``<infile>_fr.json`` in the current
-        working directory.
-    template : str
-        Which validation template to use.
-    """
-
-    if outfile is None:
-        outfile = default_outfile(fname=infile, suffix="_fr.json")
-
-    api.validate(infile=infile, template=template, fr_file=outfile)
-
-
-@click.command(name="parse")
-@click.argument(
-    "infile",
-    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
-    metavar="<infile>",
-)
-@click.option(
-    "--template",
-    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
-    metavar="<template>",
-    help="which validation template to use",
-)
-@click.option(
-    "--outfile",
-    type=click.Path(exists=False, dir_okay=False, resolve_path=True),
-    default=None,
-    help="name or path for the parsed JSON output file",
-    metavar="<outfile>",
-)
-@click.option(
-    "--grammar",
-    default="standard",
-    type=click.Choice(["standard", "getkw"]),
-    show_default=True,
-    help="which grammar to use",
-    metavar="<grammar>",
-)
-@click.option(
-    "--dump-ir/--no-dump-ir",
-    default=False,
-    help="whether to dump intermediate representation to JSON file",
-    show_default=True,
-    metavar="<dump_ir>",
-)
-def _parse(
-    infile: str, template: str, outfile: str, grammar: str, dump_ir: bool
-) -> None:
-    """Parse input file.
-
-    \b
-    Parameters
-    ----------
-    infile : str
-        The input file to be parsed.
-    template : str
-        Which validation template to use.
-    outfile : str
-        The output file. Defaults to ``<infile>_fr.json`` in the current working
-        directory.
-    grammar : str
-        Which grammar to use.
-    dump_ir : bool
-        Whether to dump intermediate representation to file.
-        False by default.
-
-    \b
-    Notes
-    -----
-    If requested, the intermediate representation is saved to
-    ``<outfile>_ir.json`` in the current working directory.
-    """
-
-    if outfile is None:
-        outfile = default_outfile(fname=infile, suffix="_fr.json")
-
-    api.parse(
-        infile=infile,
-        template=template,
-        outfile=outfile,
-        grammar=grammar,
-        dump_ir=dump_ir,
-    )
-
-
-@click.command(name="doc")
-@click.argument(
-    "template",
-    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
-    metavar="<template>",
-)
-@click.option(
-    "--outfile",
-    type=click.Path(exists=False, dir_okay=False, resolve_path=True),
-    default="input.rst",
-    show_default=True,
-    metavar="<outfile>",
-    help="where to save the generated documentation",
-)
-@click.option(
-    "--header",
-    type=str,
-    default="Input parameters",
-    show_default=True,
-    metavar="<header>",
-    help="header for the documentation page",
-)
-def _doc(template: str, outfile: str, header: str):
-    """Generate documentation from validation template.
-
-    \b
-    Parameters
-    ----------
-    template : str
-        Which validation template to use.
-    output : str
-        Where to save the generated documentation.
-        Defaults to ``input.rst`` in the current working directory.
-    header : str
-        Header for the documentation page.
-        Defaults to ``Input parameters``.
-    """
-
-    if not outfile:
-        outfile = "input.rst"
-
-    api.document(template=template, outfile=outfile, header=header)
 
 
 @click.command(name="generate")
@@ -333,7 +133,7 @@ def _generate(
     else:
         grammar_ = [Path(_).resolve() for _ in grammar]  # type: ignore
 
-    api.generate(
+    generate(
         template=template,
         where=target,
         grammar=grammar_,
@@ -343,8 +143,4 @@ def _generate(
     )
 
 
-cli.add_command(_doc)
 cli.add_command(_generate)
-cli.add_command(_lex)
-cli.add_command(_parse)
-cli.add_command(_validate)

--- a/parselglossy/documentation.py
+++ b/parselglossy/documentation.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # parselglossy -- Generic input parsing library, speaking in tongues
 # Copyright (C) 2019 Roberto Di Remigio, Radovan Bast, and contributors.
@@ -26,7 +27,6 @@
 # parselglossy library, see: <http://parselglossy.readthedocs.io/>
 #
 
-# -*- coding: utf-8 -*-
 """Documentation generation."""
 
 from typing import List  # noqa: F401
@@ -66,7 +66,7 @@ def documentation_generator(
         "- Predicates, if present, are the functions run to validate user input.\n"
     )
 
-    docs = rec_documentation_generator(template=template)
+    docs = _rec_documentation_generator(template=template)
 
     documentation = (
         header_fmt.format(comment=comment, markup=("=" * len(header)), header=header)
@@ -76,7 +76,7 @@ def documentation_generator(
     return documentation
 
 
-def document_keyword(keyword: JSONDict) -> str:
+def _document_keyword(keyword: JSONDict) -> str:
     kw_fmt = """
  :{0:s}: {1:s}
 
@@ -106,7 +106,7 @@ def document_keyword(keyword: JSONDict) -> str:
     return doc
 
 
-def rec_documentation_generator(template, *, level: int = 0) -> str:
+def _rec_documentation_generator(template, *, level: int = 0) -> str:
     """Generates documentation from a valid template.
 
     Parameters
@@ -123,25 +123,25 @@ def rec_documentation_generator(template, *, level: int = 0) -> str:
 
     keywords = template["keywords"] if "keywords" in template.keys() else []
     if keywords:
-        docs.append(indent("\n:red:`Keywords`", level))
+        docs.append(_indent("\n:red:`Keywords`", level))
 
     for k in keywords:
-        doc = document_keyword(k)
-        docs.extend(indent(doc, level))
+        doc = _document_keyword(k)
+        docs.extend(_indent(doc, level))
 
     sections = template["sections"] if "sections" in template.keys() else []
     if sections:
-        docs.append(indent("\n:red:`Sections`", level))
+        docs.append(_indent("\n:red:`Sections`", level))
         fmt = r"""
  :{0:s}: {1:s}
 """
         for s in sections:
             doc = fmt.format(s["name"], s["docstring"].replace("\n", " "))
-            doc += rec_documentation_generator(s, level=level + 1)
-            docs.extend(indent(doc, level))
+            doc += _rec_documentation_generator(s, level=level + 1)
+            docs.extend(_indent(doc, level))
 
     return "".join(docs)
 
 
-def indent(in_str: str, level: int = 0) -> str:
+def _indent(in_str: str, level: int = 0) -> str:
     return in_str.replace("\n", "\n" + ("  " * level))

--- a/parselglossy/exceptions.py
+++ b/parselglossy/exceptions.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # parselglossy -- Generic input parsing library, speaking in tongues
 # Copyright (C) 2019 Roberto Di Remigio, Radovan Bast, and contributors.
@@ -26,7 +27,6 @@
 # parselglossy library, see: <http://parselglossy.readthedocs.io/>
 #
 
-# -*- coding: utf-8 -*-
 """Error-handling facilities."""
 
 from collections import namedtuple
@@ -53,7 +53,8 @@ class Error(namedtuple("Error", ["address", "message"])):
 
     Notes
     -----
-    As we need to support Python < 3.6, we cannot use the defaults field of namedtuple.
+    As we need to support Python 3.6, we cannot use the defaults field of
+    ``namedtuple`` or ``dataclass``.
     """
 
     __slots__ = ()

--- a/parselglossy/validation_plumbing.py
+++ b/parselglossy/validation_plumbing.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # parselglossy -- Generic input parsing library, speaking in tongues
 # Copyright (C) 2019 Roberto Di Remigio, Radovan Bast, and contributors.
@@ -26,7 +27,6 @@
 # parselglossy library, see: <http://parselglossy.readthedocs.io/>
 #
 
-# -*- coding: utf-8 -*-
 """Plumbing functions powering our validation facilities."""
 
 from typing import Any, List, Optional, Tuple
@@ -36,10 +36,10 @@ from .types import allowed_types, type_fixers, type_matches
 from .utils import JSONDict, location_in_dict
 
 
-def rec_is_template_valid(template: JSONDict, *, address: Tuple = ()) -> List[Error]:
-    """Checks a template `dict` is well-formed.
+def _rec_is_template_valid(template: JSONDict, *, address: Tuple = ()) -> List[Error]:
+    """Checks a template ``dict`` is well-formed.
 
-    A template `dict` is well-formed if:
+    A template ``dict`` is well-formed if:
 
     * All keywords have:
 
@@ -73,23 +73,23 @@ def rec_is_template_valid(template: JSONDict, *, address: Tuple = ()) -> List[Er
 
     sections = template["sections"] if "sections" in template.keys() else []
     for s in sections:
-        if undocumented(s):
+        if _undocumented(s):
             errors.append(
                 Error(
                     (address + (s["name"],)),
                     "Sections must have a non-empty docstring.",
                 )
             )
-        errs = rec_is_template_valid(s, address=(address + (s["name"],)))
+        errs = _rec_is_template_valid(s, address=(address + (s["name"],)))
         errors.extend(errs)
 
     return errors
 
 
-def rec_merge_ours(
+def _rec_merge_ours(
     *, theirs: JSONDict, ours: JSONDict, address: Tuple = ()
 ) -> Tuple[JSONDict, List[Error]]:
-    """Recursively merge two `dict`-s with "ours" strategy.
+    """Recursively merge two ``dict``-s with "ours" strategy.
 
     Parameters
     ----------
@@ -104,11 +104,11 @@ def rec_merge_ours(
 
     Notes
     -----
-    The `theirs` dictionary is supposed to be the view by defaults of the
-    validation specification, whereas `ours` is the dictionary from user input.
-    The recursive merge action will generate a complete, but not validated,
-    input dictionary by using default values where these are not overridden by
-    user input, hence the naming "ours" for the merge strategy.
+    The ``theirs`` dictionary is supposed to be the view by defaults of the
+    validation specification, whereas ``ours`` is the dictionary from user
+    input. The recursive merge action will generate a complete, but not
+    validated, input dictionary by using default values where these are not
+    overridden by user input, hence the naming "ours" for the merge strategy.
     """
     outgoing = {}
     errors = []
@@ -131,7 +131,7 @@ def rec_merge_ours(
         elif not isinstance(v, dict):
             outgoing[k] = ours[k]
         else:
-            outgoing[k], errs = rec_merge_ours(
+            outgoing[k], errs = _rec_merge_ours(
                 theirs=v, ours=ours[k], address=(address + (k,))
             )
             errors.extend(errs)
@@ -139,14 +139,14 @@ def rec_merge_ours(
     return outgoing, errors
 
 
-def rec_fix_defaults(
+def _rec_fix_defaults(
     incoming: JSONDict,
     *,
     types: JSONDict,
     start_dict: JSONDict = None,
     address: Tuple = ()
 ) -> Tuple[JSONDict, List[Error]]:
-    """Fix default value and perform type checking.
+    """Fix default values and perform type checking.
 
     Parameters
     ----------
@@ -233,7 +233,7 @@ def rec_fix_defaults(
             if msg != "":
                 errors.append(Error(address + (k,), msg))
         else:
-            outgoing[k], errs = rec_fix_defaults(
+            outgoing[k], errs = _rec_fix_defaults(
                 incoming=v,
                 types=types[k],
                 start_dict=start_dict,
@@ -244,7 +244,7 @@ def rec_fix_defaults(
     return outgoing, errors
 
 
-def rec_check_predicates(
+def _rec_check_predicates(
     incoming: JSONDict,
     *,
     predicates: JSONDict,
@@ -284,7 +284,7 @@ def rec_check_predicates(
                     if not success:
                         errors.append(Error((address + (k,)), msg))
             else:
-                errs = rec_check_predicates(
+                errs = _rec_check_predicates(
                     incoming=v,
                     predicates=predicates[k],
                     start_dict=start_dict,
@@ -392,13 +392,13 @@ def run_callable(f: str, d: JSONDict, *, t: str) -> Tuple[str, Optional[Any]]:
     return msg, result
 
 
-def undocumented(x: JSONDict) -> bool:
+def _undocumented(x: JSONDict) -> bool:
     return (
         True if "docstring" not in x.keys() or x["docstring"].strip() == "" else False
     )
 
 
-def untyped(x: JSONDict) -> bool:
+def _untyped(x: JSONDict) -> bool:
     return True if "type" not in x.keys() or x["type"] not in allowed_types else False
 
 
@@ -436,10 +436,10 @@ def check_keyword(keyword: JSONDict, *, address: Tuple = ()) -> List[Error]:
             Error((address + (k,)), "Sections cannot be nested under keywords.")
         )
 
-    if untyped(keyword):
+    if _untyped(keyword):
         errors.append(Error((address + (k,)), "Keywords must have a valid type."))
 
-    if undocumented(keyword):
+    if _undocumented(keyword):
         errors.append(
             Error((address + (k,)), "Keywords must have a non-empty docstring.")
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 #
 # parselglossy -- Generic input parsing library, speaking in tongues
@@ -28,14 +29,13 @@
 # parselglossy library, see: <http://parselglossy.readthedocs.io/>
 #
 
-# -*- coding: utf-8 -*-
 """Tests for `parselglossy` package."""
 
 import json
 import re
+import subprocess
 from pathlib import Path
 from shutil import rmtree
-import subprocess
 
 import pytest
 from click.testing import CliRunner
@@ -56,138 +56,8 @@ from parselglossy.utils import as_complex
 def test_cli_switches(switch, expected):
     runner = CliRunner()
     result = runner.invoke(cli.cli, switch)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"{result.output}"
     assert re.search(expected, result.output, re.M) is not None
-
-
-@pytest.mark.parametrize(
-    "command,out,reference",
-    [
-        (
-            ["lex", "tests/cli/standard.inp"],
-            "standard_ir.json",
-            "tests/ref/standard_ir.json",
-        ),
-        (
-            [
-                "lex",
-                "tests/cli/getkw.inp",
-                "--outfile",
-                "lex_ir.json",
-                "--grammar",
-                "getkw",
-            ],
-            "lex_ir.json",
-            "tests/ref/getkw_ir.json",
-        ),
-        (
-            [
-                "validate",
-                "tests/ref/scf_ir.json",
-                "--template",
-                "tests/validation/overall/template.yml",
-            ],
-            "scf_ir_fr.json",
-            "tests/ref/scf_fr.json",
-        ),
-        (
-            [
-                "validate",
-                "tests/ref/scf_ir.json",
-                "--template",
-                "tests/validation/overall/template.yml",
-                "--outfile",
-                "scf_fr.json",
-            ],
-            "scf_fr.json",
-            "tests/ref/scf_fr.json",
-        ),
-        (
-            [
-                "parse",
-                "tests/cli/scf.inp",
-                "--template",
-                "tests/validation/overall/template.yml",
-            ],
-            "scf_fr.json",
-            "tests/ref/scf_fr.json",
-        ),
-        (
-            [
-                "parse",
-                "tests/cli/scf.inp",
-                "--template",
-                "tests/validation/overall/template.yml",
-                "--outfile",
-                "scf_fr.json",
-            ],
-            "scf_fr.json",
-            "tests/ref/scf_fr.json",
-        ),
-        (
-            [
-                "parse",
-                "tests/cli/scf.inp",
-                "--template",
-                "tests/validation/overall/template.yml",
-                "--grammar",
-                "standard",
-                "--dump-ir",
-            ],
-            "scf_fr.json",
-            "tests/ref/scf_fr.json",
-        ),
-        (["doc", "tests/cli/docs_template.yml"], "input.rst", "tests/ref/input.rst"),
-        (
-            ["doc", "tests/cli/docs_template.yml", "--outfile", "input.rst"],
-            "input.rst",
-            "tests/ref/input.rst",
-        ),
-        (
-            [
-                "doc",
-                "tests/cli/docs_template.yml",
-                "--outfile",
-                "input.rst",
-                "--header",
-                "Dwigt Rortugal's guide to input parameters",
-            ],
-            "input.rst",
-            "tests/ref/dwigt.rst",
-        ),
-    ],
-    ids=[
-        "lex-default",
-        "lex-getkw-w-outfile",
-        "validate-default",
-        "validate-w-outfile",
-        "parse-default",
-        "parse-w-outfile",
-        "parse-w-dumpir",
-        "doc-default",
-        "doc-w-outfile",
-        "doc-w-header",
-    ],
-)
-def test_cli_commands(command, out, reference):
-    runner = CliRunner()
-    result = runner.invoke(cli.cli, command)
-    assert result.exit_code == 0
-
-    # Check dumped file matches with reference
-    dumped = Path(out).resolve()
-    ref = Path(reference)
-    if command[0] == "doc":
-        with ref.open("r") as ref, dumped.open("r") as o:
-            assert o.read() == ref.read()
-    else:
-        with ref.open("r") as ref, dumped.open("r") as o:
-            assert json.loads(o.read(), object_hook=as_complex) == json.loads(
-                ref.read(), object_hook=as_complex
-            )
-
-    # Clean up file
-    dumped.unlink()
 
 
 @pytest.mark.parametrize(
@@ -233,7 +103,7 @@ def test_cli_commands(command, out, reference):
 def test_cli_generate(command, inp, references):
     runner = CliRunner()
     result = runner.invoke(cli.cli, command)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"{result.output}"
 
     parser_dir = Path.cwd() / f"{command[4]}"
 


### PR DESCRIPTION
As per discussion in #53, the CLI now only provides the `generate` subcommand.
I would leave the API as-is, for now.

I've also cleaned up some of the documentation and marked the recursive functions as internal.