### PR TITLE
Reorder template according to dependencies between default actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,14 @@ name: Test parselglossy
 
 on:
   push:
+    branches:
+      - master
   pull_request:
+    branches:
+      - master
+  release:
+    types:
+      - created
 
 jobs:
   build:

--- a/parselglossy/api.py
+++ b/parselglossy/api.py
@@ -174,7 +174,7 @@ def generate(
     stencil = read_yaml_file(template_)
 
     # Check if the template is valid
-    is_template_valid(stencil)
+    stencil = is_template_valid(stencil)
 
     with (where_ / "api.py").open("w") as f:
         f.write(generation.api_py(stencil))
@@ -330,7 +330,7 @@ def document(
     template = path_resolver(template)
     stencil = read_yaml_file(template)
 
-    is_template_valid(stencil)
+    stencil = is_template_valid(stencil)
 
     docs = documentation_generator(stencil, header=header)
 

--- a/parselglossy/generation.py
+++ b/parselglossy/generation.py
@@ -159,7 +159,7 @@ from typing import Optional, Union
 
 from .plumbing import lexer
 from .plumbing.utils import JSONDict, as_complex, path_resolver, copier
-from .plumbing.validation import is_template_valid, validate_from_dicts
+from .plumbing.validation import validate_from_dicts
 
 
 def lex(

--- a/parselglossy/utils.py
+++ b/parselglossy/utils.py
@@ -33,7 +33,7 @@ import json
 from functools import reduce
 from pathlib import Path
 from shutil import copy
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 JSONDict = Dict[str, Any]
 
@@ -169,3 +169,40 @@ def dict_to_list(d: JSONDict) -> List[Any]:
         else:
             nested_list.append([k, v])
     return nested_list
+
+
+def nested_get(d: JSONDict, *ks: str) -> Optional[Any]:
+    """Get value from a nested dictionary.
+
+    Parameters
+    ----------
+    d : JSONDict
+    ks : str
+
+    Returns
+    -------
+    v : Optional[Any]
+
+    Notes
+    -----
+    Adapted from: https://stackoverflow.com/a/40675868/2528668
+    """
+    return reduce(lambda x, k: x.get(k, None) if isinstance(x, dict) else None, ks, d)
+
+
+def nested_set(d: JSONDict, ks: Tuple[str], v: Any) -> None:
+    """Set value in nested dictionary.
+
+    Parameters
+    ----------
+    d : JSONDict
+    ks : Tuple[str]
+    v : Any
+
+    Notes
+    -----
+    Adapted from: https://stackoverflow.com/a/13688108/2528668
+    """
+    for k in ks[:-1]:
+        d = d.setdefault(k, {})
+    d[ks[-1]] = v

--- a/parselglossy/utils.py
+++ b/parselglossy/utils.py
@@ -69,7 +69,7 @@ def location_in_dict(*, address: Tuple, dict_name: str = "user") -> str:
     -------
     where : str
     """
-    return reduce(lambda x, y: x + "['{}']".format(y), address, "user")
+    return reduce(lambda x, y: x + f"['{y}']", address, "user")
 
 
 def path_resolver(f: Union[str, Path], *, touch: bool = True) -> Path:

--- a/parselglossy/utils.py
+++ b/parselglossy/utils.py
@@ -187,10 +187,14 @@ def nested_get(d: JSONDict, *ks: str) -> Optional[Any]:
     -----
     Adapted from: https://stackoverflow.com/a/40675868/2528668
     """
-    return reduce(lambda x, k: x.get(k, None) if isinstance(x, dict) else None, ks, d)
+
+    def _func(x: JSONDict, k: str) -> Optional[JSONDict]:
+        return x.get(k, None) if isinstance(x, dict) else None
+
+    return reduce(_func, ks, d)  # type: ignore
 
 
-def nested_set(d: JSONDict, ks: Tuple[str], v: Any) -> None:
+def nested_set(d: JSONDict, ks: Tuple[Any, ...], v: Any) -> None:
     """Set value in nested dictionary.
 
     Parameters

--- a/parselglossy/validation_plumbing.py
+++ b/parselglossy/validation_plumbing.py
@@ -181,7 +181,7 @@ def _rec_merge_ours(
     if difference != set():
         for k in difference:
             what = "section" if isinstance(ours[k], dict) else "keyword"
-            errors.append(Error(message="Found unexpected {}: '{}'.".format(what, k)))
+            errors.append(Error(message=f"Found unexpected {what}: '{k}'."))
 
     for k, v in theirs.items():
         if k not in ours.keys():
@@ -189,7 +189,7 @@ def _rec_merge_ours(
                 outgoing[k] = theirs[k]
             else:
                 outgoing[k] = None
-                msg = "Keyword '{0}' is required but has no value.".format(k)
+                msg = f"Keyword '{k}' is required but has no value."
                 errors.append(Error((address + (k,)), msg))
         elif not isinstance(v, dict):
             outgoing[k] = ours[k]
@@ -288,11 +288,9 @@ def _rec_fix_defaults(
                     actual = (
                         type(v).__name__
                         if type(v) is not list
-                        else "List[{}]".format(", ".join([type(x).__name__ for x in v]))
+                        else f"List[{', '.join([type(x).__name__ for x in v])}]"
                     )
-                    msg = "Actual ({0}) and declared ({1}) types do not match.".format(
-                        actual, t
-                    )
+                    msg = f"Actual ({actual}) and declared ({t}) types do not match."
             if msg != "":
                 errors.append(Error(address + (k,), msg))
         else:
@@ -376,24 +374,24 @@ def run_predicate(predicate: str, where: str, user: JSONDict) -> Tuple[str, bool
     """
 
     p = predicate.replace("value", where)
-    postfix = "in closure '{}'.".format(predicate)
+    postfix = f"in closure '{predicate}'."
 
     try:
         msg = ""
-        success = eval("lambda user: {}".format(p))(user)
+        success = eval(f"lambda user: {p}")(user)
         if not success:
-            msg = "Predicate '{}' not satisfied.".format(predicate)
+            msg = f"Predicate '{predicate}' not satisfied."
     except KeyError as e:
-        msg = "KeyError {} {:s}".format(e, postfix)
+        msg = f"KeyError {e} {postfix}"
         success = False
     except SyntaxError as e:
-        msg = "SyntaxError {} {:s}".format(e, postfix)
+        msg = f"SyntaxError {e} {postfix}"
         success = False
     except TypeError as e:
-        msg = "TypeError {} {:s}".format(e, postfix)
+        msg = f"TypeError {e} {postfix}"
         success = False
     except NameError as e:
-        msg = "NameError {} {:s}".format(e, postfix)
+        msg = f"NameError {e} {postfix}"
         success = False
 
     return msg, success
@@ -432,24 +430,21 @@ def run_callable(f: str, d: JSONDict, *, t: str) -> Tuple[str, Optional[Any]]:
     any point.
     """
 
-    closure = "lambda user: {}"
-    postfix = "in closure '{}'.".format(f)
-
     try:
         msg = ""
-        result = eval(closure.format(f))(d)
+        result = eval(f"lambda user: {f}")(d)
         result = type_fixers[t](result)
     except KeyError as e:
-        msg = "KeyError {} {:s}".format(e, postfix)
+        msg = f"KeyError {e} in closure '{f}'"
         result = None
     except SyntaxError as e:
-        msg = "SyntaxError {} {:s}".format(e, postfix)
+        msg = f"SyntaxError {e}  in closure '{f}'"
         result = None
     except TypeError as e:
-        msg = "TypeError {} {:s}".format(e, postfix)
+        msg = f"TypeError {e}  in closure '{f}'"
         result = None
     except NameError as e:
-        msg = "NameError {} {:s}".format(e, postfix)
+        msg = f"NameError {e} in closure '{f}'"
         result = None
 
     return msg, result

--- a/parselglossy/validation_plumbing.py
+++ b/parselglossy/validation_plumbing.py
@@ -346,10 +346,11 @@ def _rec_fix_defaults(
                     msg = f"Actual ({actual}) and declared ({t}) types do not match."
             if msg != "":
                 errors.append(Error(address + (k,), msg))
-            # Update start_dict.
-            # This is so that multiple dependent defaults ("chains") behave
-            # correctly. See #76 on GitHub
-            nested_set(start_dict, address + (k,), outgoing[k])
+            else:
+                # Update start_dict.
+                # This is so that multiple dependent defaults ("chains") behave
+                # correctly. See #76 on GitHub
+                nested_set(start_dict, address + (k,), outgoing[k])
         else:
             outgoing[k], errs = _rec_fix_defaults(
                 incoming=v,

--- a/parselglossy/views.py
+++ b/parselglossy/views.py
@@ -29,7 +29,7 @@
 
 """Tools to extract views of dictionaries."""
 
-from typing import Any, Callable, Optional, Type
+from typing import Any, Callable, List, Optional, Type
 
 from .exceptions import ParselglossyError
 from .utils import JSONDict
@@ -63,6 +63,21 @@ def view_by_default(d: JSONDict) -> JSONDict:
        A dictionary with a view by defaults.
     """
     return view_by("default", d)
+
+
+def view_by_default_keywords(keywords: List[JSONDict]) -> JSONDict:
+    """View by defaults only for lists of keywords.
+
+    Parameters
+    ----------
+    keywords: List[JSONDict]
+
+    Returns
+    -------
+    outgoing: JSONDict
+       A dictionary with a view by defaults for the keywords.
+    """
+    return {v["name"]: v["default"] if "default" in v else None for v in keywords}
 
 
 def view_by_docstring(d: JSONDict) -> JSONDict:

--- a/parselglossy/yaml_utils.py
+++ b/parselglossy/yaml_utils.py
@@ -28,18 +28,19 @@
 #
 
 from pathlib import Path
+from typing import Union
 
 import yaml
 
 from .utils import JSONDict
 
 
-def read_yaml_file(file_name: Path) -> JSONDict:
+def read_yaml_file(file_name: Union[str, Path]) -> JSONDict:
     """Reads a YAML file and returns it as a dictionary.
 
     Parameters
     ----------
-    file_name: Path
+    file_name: Union[str, Path]
         Path object for the YAML file.
 
     Returns
@@ -47,6 +48,9 @@ def read_yaml_file(file_name: Path) -> JSONDict:
     d: JSONDict
         A dictionary with the contents of the YAML file.
     """
+
+    file_name = Path(file_name) if isinstance(file_name, str) else file_name
+
     with file_name.open("r") as f:
         try:
             d = yaml.safe_load(f)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,23 @@ line_length = 88
 [tool.black]
 exclude = 'pyparsing.py'
 
+[tool.pytest.ini_options]
+addopts = "-rws"
+testpaths = [
+    "tests",
+]
+norecursedirs = [
+  "env",
+  ".direnv",
+  "venv",
+  ".env",
+  ".venv",
+  "docs",
+  ".eggs",
+  ".git",
+]
+collect_ignore = ["setup.py"]
+
 [build-system]
 requires = ["flit_core >=2,<4"]
 build-backend = "flit_core.buildapi"

--- a/tests/test_check_template.py
+++ b/tests/test_check_template.py
@@ -277,4 +277,4 @@ check_template_data = [
 )
 def test_check_template(template, raises):
     with raises:
-        is_template_valid(template)
+        template = is_template_valid(template)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -28,7 +28,6 @@
 #
 
 import json
-import re
 from contextlib import ExitStack as does_not_raise
 from pathlib import Path
 from typing import List
@@ -221,6 +220,20 @@ validation_data = (
             "template_all_default.yml",
             None,
             {"foobar": True, "foo": {"bar": False}},
+            [""],
+        ),
+        (
+            "overall",
+            "input_ordering.yml",
+            "ordering.yml",
+            None,
+            {
+                "flavor": 2.0,
+                "color": 2.0,
+                "charge": 2.0,
+                "spectator": "nothing to see",
+                "adorable_kitten": {"flavor": 1.0, "color": 1.5, "charge": 1.0,},
+            },
             [""],
         ),
     ]

--- a/tests/validation/overall/input_ordering.yml
+++ b/tests/validation/overall/input_ordering.yml
@@ -1,0 +1,4 @@
+flavor: 2.0
+spectator: "nothing to see"
+adorable_kitten:
+  flavor: 1.0

--- a/tests/validation/overall/ordering.yml
+++ b/tests/validation/overall/ordering.yml
@@ -1,0 +1,32 @@
+keywords:
+  - name: flavor
+    type: float
+    docstring: "Foo"
+  - name: color
+    type: float
+    default: "user['charge']"
+    docstring: "Baz"
+  - name: charge
+    type: float
+    default: "user['flavor']"
+    docstring: "Bar"
+  - name: spectator
+    type: str
+    docstring: |
+      A spectator keyword
+sections:
+  - name: adorable_kitten
+    docstring: |
+      A section in our input tree
+    keywords:
+      - name: flavor
+        type: float
+        docstring: "Foo"
+      - name: color
+        type: float
+        default: "1.5 * user['adorable_kitten']['charge']"
+        docstring: "Baz"
+      - name: charge
+        type: float
+        default: "user['adorable_kitten']['flavor']"
+        docstring: "Bar"


### PR DESCRIPTION
Fixes #76, that is the "nondegenerate" case of #96 
The reordering is done _after_ checking that the template is valid: I assume that there are no cyclic dependencies at this point.
I also use the fact that dependencies can only appear in lists of keywords, not between sections. The algorithm looks like this:
1. Generate `DiGraph` of dependencies for defaults for the list of keywords within the top-level section. I have added the plumbing function `view_by_default_keywords` to get a view of defaults only for the keywords (_i.e._ non-recursive) This is a copy-paste of the work of @bast to detect cycles.
2. Iterate over nodes in the `DiGraph` and check whether a keyword in the list of keywords has the same name as a node. If yes, deep copy them to a `shuffle` list and remove them from the original list. This effectively splits the list of keywords for the top-level section into two parts: "spectator" keywords, _i.e._ those that are independent of other keywords in the list, and "dependent" keywords (in the `shuffle` list). Once we're done we can append the `shuffle` list to the "spectator" list. Given that we loop over nodes in the `DiGraph` the `shuffle` list is already in the desired order.
3. Recursion over sections in the template.

Step 2 is a bit wasteful as we loop over all keywords for all nodes in the `DiGraph` so it's quadratic in the number of keywords in the worst case. I will not waste time optimizing this as I think it's not a problem in the slightest.

### Other changes in this PR not related to the topic
- Change some `.format` to `f`-strings
- Change the testing workflow so we run once (for PR) and not twice (for PR and branch) on every commit
- Add pytest configuration to `pyproject.toml` This will only have an effect for very recent pytest versions