### PR TITLE
Locate hard-copy of `pyparsing` *inside* `plumbing` folder

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,15 +42,15 @@ jobs:
 
       - name: Flake8 lints
         run: |
-          python -m pytest --flake8 parselglossy
+          python -m flake8 parselglossy
 
       - name: Black lints
         run: |
-          python -m pytest --black parselglossy
+          python -m black --check parselglossy
 
       - name: Mypy lints
         run: |
-          python -m pytest --mypy parselglossy
+          python -m mypy parselglossy
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,10 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 5.0.3
+    hooks:
+      - id: flake8
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.3.0
     hooks:

--- a/parselglossy/api.py
+++ b/parselglossy/api.py
@@ -153,7 +153,7 @@ def generate(
             copier(x, where_ / "plumbing")
         # copy pyparsing
         ppfolder = Path(ppfile).parent
-        dest = where_ / "pyparsing"
+        dest = where_ / "plumbing/pyparsing"
         copytree(ppfolder, dest, ignore=ignore_patterns("__pycache__"))
         folder_permissions(dest)
         # extract `parse_string_to_dict` and write it into `getkw.py`

--- a/parselglossy/grammars/atoms.py
+++ b/parselglossy/grammars/atoms.py
@@ -34,9 +34,10 @@ from typing import Any, List, Union
 
 try:
     import pyparsing as pp
+
     if pp.__version__.split(".")[0] < "3":
-       # Import local copy
-       from . import pyparsing as pp  # type: ignore
+        # Import local copy
+        from . import pyparsing as pp  # type: ignore
 except ImportError:
     # Import local copy
     from . import pyparsing as pp  # type: ignore

--- a/parselglossy/grammars/atoms.py
+++ b/parselglossy/grammars/atoms.py
@@ -34,6 +34,9 @@ from typing import Any, List, Union
 
 try:
     import pyparsing as pp
+    if pp.__version__.split(".")[0] < "3":
+       # Import local copy
+       from . import pyparsing as pp  # type: ignore
 except ImportError:
     # Import local copy
     from . import pyparsing as pp  # type: ignore

--- a/parselglossy/grammars/getkw.py
+++ b/parselglossy/grammars/getkw.py
@@ -43,6 +43,9 @@ from .atoms import (
 
 try:
     import pyparsing as pp
+    if pp.__version__.split(".")[0] < "3":
+       # Import local copy
+       from . import pyparsing as pp  # type: ignore
 except ImportError:
     # Import local copy
     from . import pyparsing as pp  # type: ignore

--- a/parselglossy/grammars/getkw.py
+++ b/parselglossy/grammars/getkw.py
@@ -43,9 +43,10 @@ from .atoms import (
 
 try:
     import pyparsing as pp
+
     if pp.__version__.split(".")[0] < "3":
-       # Import local copy
-       from . import pyparsing as pp  # type: ignore
+        # Import local copy
+        from . import pyparsing as pp  # type: ignore
 except ImportError:
     # Import local copy
     from . import pyparsing as pp  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,10 +74,7 @@ test = [
     "coverage",
     "hypothesis",
     "pytest",
-    "pytest-black",
     "pytest-cov",
-    "pytest-flake8",
-    "pytest-mypy",
     "pytest-sugar",
 ]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,5 @@
 [tool.isort]
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-line_length = 88
+profile = "black"
 
 [tool.pytest.ini_options]
 addopts = "-rws --ignore=setup.py"


### PR DESCRIPTION
Fixes a bug in the generated parser where `pyparsing` could not be found.